### PR TITLE
corrected connection string in __init__.py 

### DIFF
--- a/newsletter/__init__.py
+++ b/newsletter/__init__.py
@@ -3,7 +3,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
 
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///newsletter_automation.sqlite3'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://root:root@127.0.0.1/newsletter_automation'
 app.config['SECRET_KEY'] = "random string"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 


### PR DESCRIPTION
In this PR I have just corrected the connection string for SQLALCHEMY_DATABASE_URI in the __init__.py
Changed to 'mysql+pymysql://root:root@127.0.0.1/newsletter_automation' from 'sqlite:///newsletter_automation.sqlite3'