### PR TITLE
Modified files to get the latest package addition from requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,6 @@ recursive-include  newsletter_automation/newsletter/templates *
 recursive-include  newsletter_automation/newsletter/static *
 recursive-include  newsletter_automation/newsletter/static/css *
 recursive-include  newsletter_automation/newsletter/static/img *
+include requirements.txt
+
 global-exclude *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,13 @@ if os.path.exists('./README.md'):
     with open('./README.md', 'r', encoding='utf=8') as fh:
         long_description = fh.read()
 
+# There isn't a cleaner solution to get the latest package addition to requirements.txt
+# We are using https://stackoverflow.com/a/14399775
+# ^ solution also requires https://stackoverflow.com/questions/38533669/include-requirements-txt-file-in-python-wheel
+if os.path.exists('./requirements.txt'):
+    with open('./requirements.txt', 'r', encoding='utf-8') as rfh:
+        packages_required = rfh.read().splitlines()
+
 setuptools.setup(
         name = 'newsletter_automation',
         version = '0.0.3',
@@ -23,13 +30,6 @@ setuptools.setup(
         packages = ['newsletter_automation'],
         zip_safe = False,
         include_package_data = True,
-        install_requires = [
-            'Flask',
-            'Flask-WTF',
-            'flask-sqlalchemy',
-            'pytz',
-            'PyMySQL==1.0.2',
-            'oauthlib==3.1.1',
-            'mailchimp-marketing==3.0.44'],
+        install_requires = packages_required,
         python_requires = '>=3.8'
         )


### PR DESCRIPTION
Adding new packages to the `requirement.txt` file is being missed during the *Newsletter app* Python package creation, the changes in this branch will parse the `requirements.txt` file and install them with the  *Newsletter app* Python package install itself.