### PR TITLE
URL field checks- valid url, no spaces in URL

### DIFF
--- a/newsletter_automation/newsletter/forms.py
+++ b/newsletter_automation/newsletter/forms.py
@@ -3,10 +3,9 @@
 from flask_wtf import FlaskForm
 from flask_wtf.recaptcha import validators
 from wtforms import TextField, TextAreaField, SubmitField
+from wtforms.fields.html5 import URLField
 from wtforms.fields.core import Label, StringField
-from wtforms.validators import DataRequired, Length,ValidationError
-from wtforms_components import TimeField
-from wtforms.validators import DataRequired, Length
+from wtforms.validators import DataRequired, Length,ValidationError,url
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from . models import Article_category
 
@@ -21,9 +20,9 @@ def choice_query():
 
 #To add articles data
 class AddArticlesForm(FlaskForm):
-    url= TextField('url', validators= [DataRequired()])
-    title = TextField('Title', validators= [DataRequired()])
-    description = TextAreaField('Description', validators = None)
-    time = TextField('Time',validators = None)
+    url = URLField('url', validators=[DataRequired(), url()])
+    title = TextField('Title')
+    description = TextAreaField('Description')
+    time = TextField('Time')
     category_id = QuerySelectField(query_factory=choice_query, allow_blank=True,get_label='category_name')
     submit = SubmitField('Add Article')

--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -101,19 +101,8 @@ def articles():
         category = AddArticlesForm(request.form)
         if request.method == 'POST':
             if addarticlesform.submit.data:
-                category1 = request.form.get('category_id')
-                if category1 == '1':
-                    pass
-                else:
-                    if not(addarticlesform.description.data):
-                        flash("Please Provide Description")
-                        return render_template('articles.html',addarticlesform=addarticlesform, category=category)
-                    if not (addarticlesform.time.data):
-                        flash("Please Provide Time")
-                        return render_template('articles.html',addarticlesform=addarticlesform, category=category)
-            
-            article = Articles(addarticlesform.url.data,addarticlesform.title.data,addarticlesform.description.data, addarticlesform.time.data, addarticlesform.category_id.data.category_id)
-            db.session.add(article)
+                article = Articles(addarticlesform.url.data,addarticlesform.title.data,addarticlesform.description.data, addarticlesform.time.data, addarticlesform.category_id.data.category_id)
+                db.session.add(article)
             try:
                 if url == db.session.query(Articles).filter(Articles.url == addarticlesform.url.data).one_or_none():
                     msg = ""


### PR DESCRIPTION
Implemented the following checks for URL:

1. Only valid URLs are taken by the field. e.g. www.google.com won't be accepted as a valid URL but https://www.google.com will be accepted as a valid URL.
2.  If the user enters space then, that will be highlighted as please enter valid URL.
3. Duplicate check is already implemented in routes.py

The video for the check:

https://drive.google.com/file/d/1AJ4AC1h9pSiJjJQBwnaqq60vyzdty60h/view?usp=sharing

To support blank category- following query need to be run in the production DB
use newsletter_automation;
Insert into article_category (category_name) values ('');


https://drive.google.com/file/d/1JUEb-Bo9UOrUbsUEtRAufE6NZuug4YKV/view?usp=sharing