### PR TITLE
removed extra } from template which was breaking the url

### DIFF
--- a/newsletter_automation/helpers/Editable_Newsletter_Template.html
+++ b/newsletter_automation/helpers/Editable_Newsletter_Template.html
@@ -743,7 +743,7 @@
                         
                         <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 							{% for article in newsletter_json['past_articles'] %}
-                            <a href="{{article.url}}}" target="_blank"><strong>{{article.title}}</strong></a><strong>&nbsp;</strong>{{article.description}}<br>
+                            <a href="{{article.url}}" target="_blank"><strong>{{article.title}}</strong></a><strong>&nbsp;</strong>{{article.description}}<br>
 <br>
 <span style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif"><strong>Reading time:</strong>&nbsp;{{article.reading_time}} &nbsp;minutes<br>
 <br>


### PR DESCRIPTION
Issue - Articles added under a past week - show error when URL is clicked from Mailchimp. 

Reason - URL is appended with %7D at the end which makes the URL invalid

Fix - In the template file, there is an extra } in the past week's article URL parameter.