### PR TITLE
updated exposed /api/articles/ returns json response instead html

### DIFF
--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -109,10 +109,13 @@ def add_articles():
                 msg = e
             #db.session.commit()
             #msg = "Record added Successfully"
+            if request.path == '/api/articles':
+                return jsonify({'message':msg}),200
             return render_template('result.html', msg=msg)
     except Exception as e:
         app.logger.error(e)
-
+    if request.path == '/api/articles':
+        return jsonify({'error':'check if url in the payload is duplicate'}),400
     return render_template('articles.html',addarticlesform=addarticlesform, category=category)
 
 @app.route('/articles', methods=['GET', 'POST'])


### PR DESCRIPTION
with this change , exposed /api/articles/ call will return jsonify response instead html 
{
    "message": "Record added Successfully"
}

Testing:
Have tested web api call @app.route('/articles') should work as it was earlier & curl requests @app.route('api/articles') does return json response now 