### PR TITLE
Changed the button layout in manage articles page

### DIFF
--- a/newsletter_automation/newsletter/templates/manage_articles.html
+++ b/newsletter_automation/newsletter/templates/manage_articles.html
@@ -3,10 +3,16 @@
 {%include "menu.html" %}
 {% block content %}
 <div class="logoutLblPos">
+    <button type = "button" onclick =
+    "location.href = './home'">
+    Go back to Home
+    </button>
+
     <button type="button" onclick="location.href = '/logout'">
         Logout
     </button>
 </div>
+
 <div class="container">
     <div class="row">
         <div class="col md-12">
@@ -43,12 +49,6 @@
                         {% endfor %}
                     </table>
                     <br></br>
-                    <div>
-                        <button type = "button" onclick =
-                        "location.href = './home'">
-                        Go back to Home
-                    </button>
-                    </div>
 
                    
             </form>


### PR DESCRIPTION
In this PR I have changed the button layout in manage articles page so that the `Go back home button` and `logout` button is at one place, on the top right corner

Files changed:
- newsletter_automation/newsletter/templates/manage_articles.html
![manage_articles](https://user-images.githubusercontent.com/52410419/152646633-ead2d37b-aa75-411a-a2c1-9c92fbeaf022.PNG)
