### PR TITLE
reading time taking numbers only

### DIFF
--- a/newsletter_automation/newsletter/edit_article_form.py
+++ b/newsletter_automation/newsletter/edit_article_form.py
@@ -1,7 +1,7 @@
 """Flask Form To edit articles"""
 from flask_wtf import FlaskForm
-from wtforms import TextField, TextAreaField, SubmitField,SelectField
-from wtforms.validators import DataRequired, Length
+from wtforms import TextField, TextAreaField, SubmitField,SelectField, IntegerField
+from wtforms.validators import DataRequired, Length, NumberRange
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from . models import Article_category
 
@@ -22,6 +22,6 @@ class EditArticlesForm(FlaskForm):
     url= TextField('url', validators= [DataRequired()])
     title = TextField('title', validators= [DataRequired()])
     description = TextAreaField('description', validators= [ DataRequired(), Length(min=4)])
-    time = TextField('time',validators=[ DataRequired()])
+    time = IntegerField('time',validators=[NumberRange(min=1, max=120, message="Please provide a valid number")])
     category_id= SelectField(choices=fetch_categories())
     submit = SubmitField('Save Article')

--- a/newsletter_automation/newsletter/templates/edit_article.html
+++ b/newsletter_automation/newsletter/templates/edit_article.html
@@ -19,14 +19,14 @@
                     <th>URL</th>
                     <th>Title</th>
                     <th>Description</th>
-                    <th>Reading Time</th>
+                    <th>Reading Time(in Minutes)</th>
                     <th>Category</th>
                 </tr>
                 <tr>
                     <td> {{ form.url(id="url",placeholder="URL")}} </td>
                     <td> {{ form.title(id="title",placeholder="Title")}} </td>
                     <td> {{ form.description(id="description",placeholder="Description")}} </td>
-                    <td> {{ form.time(placeholder="Time",id="time") }} </td>
+                    <td> {{ form.time(placeholder="Time",id="time", type="number", min="1", max="120") }} </td>
                     <td> {{ form.category_id(placeholder="category",id="category_id") }} </td>
                     <td> {{ form.submit(class="btn btn-lg btn-primary btn-block")}} </td>
                     <td> <a href="/manage-articles" class="btn btn-success">Cancel</a> </td>


### PR DESCRIPTION
This PR is for following ticket:
https://trello.com/c/IW9MbVWl/24-edit-article-page-reading-time-should-limit-to-numbers

The changes I made:

I've made time field as Integer field on the edit form, which will accept integer numbers from 1 to 60.

I've tried using time field, but it is not working as I am getting security error.

