### PR TITLE
added word-wrap style to table data

### DIFF
--- a/newsletter_automation/newsletter/templates/manage_articles.html
+++ b/newsletter_automation/newsletter/templates/manage_articles.html
@@ -24,10 +24,9 @@
                         </tr>
                         {% for articles in article_data %}
                         <tr>
-
                             <td> {{articles.title}}</td>
-                            <td> {{articles.url}}</td>
-                            <td> {{articles.description}}</td>
+                            <td style="word-wrap: break-word;min-width: 200px;max-width: 300px;"> {{articles.url}}</td>
+                            <td style="word-wrap: break-word;min-width: 200px;max-width: 300px;"> {{articles.description}}</td>
                             <td> {{articles.time}}</td>
                             <td> {{articles.newsletter_id}}</td>
 


### PR DESCRIPTION
This PR is for following ticket:
https://trello.com/c/zpqI8xtV/2-fix-manage-articles-page-layout

Made changes in the file `manage_articles.html`

Added a style `word-wrap` for the table data for `url` and `description` fields