### PR TITLE
Fix manage articles layout

### DIFF
--- a/newsletter_automation/newsletter/templates/manage_articles.html
+++ b/newsletter_automation/newsletter/templates/manage_articles.html
@@ -28,26 +28,24 @@
                 <table id="tableID" class="table table-hover ">
                     <thead>
                         <tr>
-
-                            <th>Title</th>
-                            <th>URL</th>
-                            <th>Description</th>
-                            <th>Reading Time</th>
-                            <th>Newsletter Id</th>
+                            <th class="col-md-2">Title</th>
+                            <th class="col-md-3">URL</th>
+                            <th class="col-md-4">Description</th>
+                            <th class="col-md-1">Newsletter Id</th>
+                            <th class="col-md-1">Action</th>
                         </tr>
                     </thead>
-                    
+
                 <tbody>
                         {% for articles in article_data %}
                         <tr>
 
-                            <td> {{articles.title}}</td>
-                            <td> {{articles.url}}</td>
-                            <td> {{articles.description}}</td>
-                            <td> {{articles.time}}</td>
-                            <td> {{articles.newsletter_id}}</td>
+                            <td style ="word-break:break-all;"> {{articles.title}}</td>
+                            <td style ="word-break:break-all;"> {{articles.url}}</td>
+                            <td style ="word-break:break-all;"> {{articles.description}}</td>
+                            <td style ="word-break:break-all;"> {{articles.newsletter_id}}</td>
 
-                            <td>
+                            <td style ="word-break:break-all;">
                                 <a href="/edit/{{articles.article_id}}" class="btn btn-primary btn-xs"
                                     >Edit</a>
                                 <a href="/delete/{{articles.article_id}}" class="btn btn-danger btn-xs"
@@ -57,17 +55,17 @@
 
                         </tr>
                         {% endfor %}
-                </tbody> 
+                </tbody>
                 </table>
                 </div>
-                    
+
                     <br></br>
                     <div>
                         <button type = "button" onclick =
                         "location.href = './home'">
                         Go back to Home
                     </button>
-                    </div>     
+                    </div>
             </form>
             </div>
         </div>
@@ -79,8 +77,8 @@
                 "columnDefs": [
                     { "visible": false },
                     {
-                        "targets": [1, 2, 3, 4, 5],
-                        "orderable": false,
+                        "targets": [1, 2, 3, 4],
+                        "orderable": true,
 
                     }]
             });

--- a/newsletter_automation/newsletter/templates/manage_articles.html
+++ b/newsletter_automation/newsletter/templates/manage_articles.html
@@ -25,7 +25,7 @@
         <div class="col md-12">
             <form method="POST" , action="">
                 <legend>Manage Articles </legend>
-                <table id="tableID" class="table table-hover ">
+                <table id="tableID" class="table table-hover">
                     <thead>
                         <tr>
                             <th class="col-md-2">Title</th>
@@ -41,7 +41,7 @@
                         <tr>
 
                             <td style ="word-break:break-all;"> {{articles.title}}</td>
-                            <td style ="word-break:break-all;"> {{articles.url}}</td>
+                            <td style ="word-break:break-all;"> <a href="{{articles.url}}">{{articles.url}}</a></td>
                             <td style ="word-break:break-all;"> {{articles.description}}</td>
                             <td style ="word-break:break-all;"> {{articles.newsletter_id}}</td>
 


### PR DESCRIPTION
@ajitava-git , I fixed the layout problem on the manage-articles page, where the table was overflowing the page width. 

**Implementation notes**
1. The cause for this error seems to be the way wide tables work within a bootstrap container. Other folks have had this problem before and I used [this solution](https://stackoverflow.com/a/22898192) on StackOverflow.

2. I removed the `Reading Time` column from the table since it did not give a user any meaningful information

3. I set the column widths for each of the table columns. I did this so we had consistent visuals irrespective of which column had the longest string. The previous column widths were set to auto which meant that the page looked different depending on which columns had the longest string.

4. I cleaned up the HTML formatting. I had to remove a couple of useless div tags and a completely useless form tag.

**Testing notes:**
I have tested the following:

a) The table does not spill out of the container on Brave and Chrome. 
b) I have tried resizing my browser width and the table overflow problem does not happen
c) *NOT WORKING* I tested using other devices but the problem continues with smaller phones, etc. I did not go about fixing this issue since we do not support newsletter generator on mobile devices and tablets.
d) I briefly tested table functionality (search, pagination, next/previous, table row count, etc.) and they seemed ok on my local instance.

I am attaching a couple of screenshots of before fix and after fix that I see on my machine.

*BEFORE FIX*
![BAD_before_fix](https://user-images.githubusercontent.com/4759449/170240585-d8c4b723-402c-429f-bf12-7c311c043a4b.png)

*AFTER FIX*
![GOOD_after_fix](https://user-images.githubusercontent.com/4759449/170240607-32b88e96-d405-4fb6-8ce2-5e4a1b607843.png)




