### PR TITLE
Made the number of rows in thead and tbody equal.

### DIFF
--- a/newsletter_automation/newsletter/templates/manage_articles.html
+++ b/newsletter_automation/newsletter/templates/manage_articles.html
@@ -34,9 +34,10 @@
                             <th>Description</th>
                             <th>Reading Time</th>
                             <th>Newsletter Id</th>
+                            <th>Action</th>
                         </tr>
                     </thead>
-                    
+
                 <tbody>
                         {% for articles in article_data %}
                         <tr>
@@ -57,17 +58,17 @@
 
                         </tr>
                         {% endfor %}
-                </tbody> 
+                </tbody>
                 </table>
                 </div>
-                    
+
                     <br></br>
                     <div>
                         <button type = "button" onclick =
                         "location.href = './home'">
                         Go back to Home
                     </button>
-                    </div>     
+                    </div>
             </form>
             </div>
         </div>


### PR DESCRIPTION
I was noticing a console error every time I visited the manage-articles page. I dug around and found the root cause was because the thead and tbody within the datatable had an inconsistent number of columns. So I added an 'Actions' column to thead. 

**Error**
jquery-3.5.1.js:4055 Uncaught TypeError: Cannot read properties of undefined (reading 'style')

[Solution link](https://stackoverflow.com/questions/25377637/datatables-cannot-read-property-mdata-of-undefined)

**Testing notes**
1. Simply visited the page again with the fix and noticed the error was no longer present.