### PR TITLE
Fixed regression of used articles showing up on manage articles page

### DIFF
--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -371,7 +371,7 @@ def manage_articles():
     "This method filers out unpublished articles"
     try:
         add_articles_form = AddArticlesForm(request.form)
-        article_data = Articles.query.filter(Articles.newsletter_id == None).all()
+        article_data = Articles.query.filter(Articles.newsletter_id == None).order_by(Articles.article_id.desc()).all()
     except Exception as e:
         app.logger.error(e)
     return render_template('manage_articles.html', addarticlesform=add_articles_form,article_data=article_data)

--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -371,7 +371,7 @@ def manage_articles():
     "This method filers out unpublished articles"
     try:
         add_articles_form = AddArticlesForm(request.form)
-        article_data = Articles.query.order_by(Articles.article_id.desc()).all()
+        article_data = Articles.query.filter(Articles.newsletter_id == None).all()
     except Exception as e:
         app.logger.error(e)
     return render_template('manage_articles.html', addarticlesform=add_articles_form,article_data=article_data)


### PR DESCRIPTION
We had a feature to hide used articles from the manage-articles page. It looks like we introduced a regression when making a merge. I have redone the work needed to hide the used article.

**Implementation notes**
1. I literally gitk-ed routes.py and noticed how /manage-articles had changed
2. It looks like we overwrote the new filter. So I introduced it again.
3. I have included Raji's change that caused the regression into this PR as well. 

We need to be doing two things when fetching articles for the managed articles page:
a) Filter out any article that does not have newsletter id set to `None`
b) sort the list by id desc

**Testing notes**
I tested this fix locally and it looked ok. Used articles are no longer being shown in the manage-articles page. The articles being shown on the manage-articles page are sorted by latest added. I looked for potential regressions on the old articles page and did not notice any. 