### PR TITLE
Added category id to the manage articles page

### DIFF
--- a/newsletter_automation/newsletter/templates/manage_articles.html
+++ b/newsletter_automation/newsletter/templates/manage_articles.html
@@ -21,6 +21,7 @@
                             <th class="col-md-2">Title</th>
                             <th class="col-md-3">URL</th>
                             <th class="col-md-5">Description</th>
+                            <th class="col-md-1" data-toggle="tooltip" data-placement="top" title="Comic = 1  Past article = 2  Current week = 3  Automation corner = 4">Category</th>
                             <th class="col-md-1">Action</th>
                         </tr>
                     </thead>
@@ -31,6 +32,7 @@
                             <td style="word-break:break-all;"> {{articles.title}}</td>
                             <td style="word-break:break-all;"> <a href="{{articles.url}}">{{articles.url}}</a></td>
                             <td style="word-break:break-all;"> {{articles.description}}</td>
+                            <td style="word-break:break-all;"> {{articles.category_id}}</td>
                             <td style="word-break:break-all;">
                                 <a href="/edit/{{articles.article_id}}" class="btn btn-sm btn-primary">Edit</a>
                                 <a href="/delete/{{articles.article_id}}" class="btn btn-sm btn-danger"
@@ -49,6 +51,7 @@
 {% block js_static %}
 <script>
     $(document).ready(function () {
+        $('[data-toggle="tooltip"]').tooltip();
         $('#tableID').DataTable({
             "order": [],
             "columnDefs": [


### PR DESCRIPTION
We can now see category on the manage articles page. This was a feature that the previous newsletter team wanted. 