### PR TITLE
Made the API CSRF exempt

### DIFF
--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -19,6 +19,7 @@ import newsletter.sso_google_oauth as sso
 from helpers.authentication_required import Authentication_Required
 
 from newsletter import forms
+from newsletter import csrf
 
 articles_added=[]
 article_id_list=[]
@@ -92,7 +93,7 @@ def add_articles():
     try:
         addarticlesform = AddArticlesForm(request.form)
         category = AddArticlesForm(request.form)
-        if request.method == 'POST' and addarticlesform.validate():
+        if request.method == 'POST' and (addarticlesform.validate() or request.path == '/api/articles'):
             article = Articles(addarticlesform.url.data,addarticlesform.title.data,addarticlesform.description.data, addarticlesform.time.data, addarticlesform.category_id.data.category_id)
             db.session.add(article)
             try:
@@ -100,7 +101,7 @@ def add_articles():
                     msg = ""
                 else:
                     db.session.commit()
-                    msg = "Record added Successfully"
+                    msg = "Record added successfully"
             except MultipleResultsFound as e:
                 msg = "URL already exists in database"
             if request.path == '/api/articles':
@@ -120,6 +121,7 @@ def articles():
 
 @app.route('/api/articles', methods=['POST'])
 @Authentication_Required.requires_apikey
+@csrf.exempt
 def api_article():
     """To add articles through api endpoints"""
     return add_articles()


### PR DESCRIPTION
__Root cause:__ When we added CSRF protection, we automatically added it to every single endpoint. So what ended up happening was that our special 'API-only' endpoint also got protection. 

__Fix:__ The fix has two parts. One, I had to make the /api/articles endpoint CSRF exempt. Two, I had to bypass form validation if the endpoint was being called. I needed step 2 because we have not implemented the API endpoint cleanly. 


More debug notes on Trello.