### PR TITLE
data validation on description field

### DIFF
--- a/tests/data_validation/great_expectations/expectations/articles.json
+++ b/tests/data_validation/great_expectations/expectations/articles.json
@@ -1,7 +1,23 @@
 {
   "data_asset_type": null,
   "expectation_suite_name": "articles",
-  "expectations": [],
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "description",
+        "min_value": 15
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "description"
+      },
+      "meta": {}
+    }
+  ],
   "ge_cloud_id": null,
   "meta": {
     "citations": [
@@ -12,10 +28,10 @@
           "datasource_name": "newsletter_automation_datasource",
           "limit": 1000
         },
-        "citation_date": "2022-07-14T09:13:09.802558Z",
+        "citation_date": "2022-07-18T07:57:13.053323Z",
         "comment": "Created suite added via CLI"
       }
     ],
-    "great_expectations_version": "0.15.12"
+    "great_expectations_version": "0.15.14"
   }
 }


### PR DESCRIPTION
My Task: Verify that there are no lazy one liners in the description of the articles page.

Steps followed:
description field validation comes under article test suite
great_expectations suite edit article 
Jupyter notebook opened and added required steps to fetch data from article table and added description field validation using the below method.

From greater expectations library I have used 
expect_column_values_to_not_be_null
and
expect_column_values_to_be_betwee

for method expect_column_values_to_be_betwee, we need to pass 3 parameters, 1. column name 2. min_value 3. max_value
as per entries in description field I have decided the min_value as 15 and max_value as None. 