### PR TITLE
Added test to verify current week article

### DIFF
--- a/tests/data_validation/great_expectations/checkpoints/newsletter_automation.yml
+++ b/tests/data_validation/great_expectations/checkpoints/newsletter_automation.yml
@@ -47,7 +47,14 @@ validations:
       data_asset_name: newsletter_automation.newsletter_campaign
       data_connector_query:
         index: -1
-    expectation_suite_name: newsletter_campaign     
+    expectation_suite_name: newsletter_campaign
+  - batch_request:
+      datasource_name: newsletter_automation_datasource
+      data_connector_name: default_inferred_data_connector_name
+      data_asset_name: newsletter_automation.articles
+      data_connector_query:
+        index: -1
+    expectation_suite_name: verify_current_week_article
 
 profilers: []
 ge_cloud_id:

--- a/tests/data_validation/great_expectations/expectations/verify_current_week_article.json
+++ b/tests/data_validation/great_expectations/expectations/verify_current_week_article.json
@@ -1,0 +1,21 @@
+{
+  "data_asset_type": null,
+  "expectation_suite_name": "verify_current_week_article",
+  "expectations": [],
+  "ge_cloud_id": null,
+  "meta": {
+    "citations": [
+      {
+        "batch_request": {
+          "data_asset_name": "newsletter_automation.articles",
+          "data_connector_name": "default_inferred_data_connector_name",
+          "datasource_name": "newsletter_automation_datasource",
+          "limit": 1000
+        },
+        "citation_date": "2022-07-22T10:42:58.622567Z",
+        "comment": "Created suite added via CLI"
+      }
+    ],
+    "great_expectations_version": "0.15.15"
+  }
+}


### PR DESCRIPTION
Task: Test to check if atleast one current week article has title and description filled.
 **Steps**
- Created new test  suite `verify_current_week_article.json`
- Added the test suite under checkpoint .yaml file
-  Using `newsletter_automation.article` table as datasource
-  First checking if there are articles present that  has not already been included in newsletter by checking for articles with newsletter_id  `null`
-  Then checking if description and title is filled for articles with` category_id` of 3
Expectations used:
`expect_column_values_to_be_between`
`expect_column_values_to_be_null`
