### PR TITLE
added test to verify comic title

### DIFF
--- a/tests/data_validation/great_expectations/checkpoints/newsletter_automation.yml
+++ b/tests/data_validation/great_expectations/checkpoints/newsletter_automation.yml
@@ -47,7 +47,15 @@ validations:
       data_asset_name: newsletter_automation.newsletter_campaign
       data_connector_query:
         index: -1
-    expectation_suite_name: newsletter_campaign     
+    expectation_suite_name: newsletter_campaign  
+    expectation_suite_name: articles
+  - batch_request:
+      datasource_name: newsletter_automation_datasource
+      data_connector_name: default_inferred_data_connector_name
+      data_asset_name: newsletter_automation.articles
+      data_connector_query:
+        index: -1
+    expectation_suite_name: comic_title_validation 
 
 profilers: []
 ge_cloud_id:

--- a/tests/data_validation/great_expectations/expectations/comic_title_validations.json
+++ b/tests/data_validation/great_expectations/expectations/comic_title_validations.json
@@ -1,0 +1,33 @@
+{
+  "data_asset_type": null,
+  "expectation_suite_name": "comic_title_validations",
+  "expectations": [
+    {
+      "expectation_type": "expect_column_value_lengths_to_be_between",
+      "kwargs": {
+        "column": "title",
+        "condition_parser": "great_expectations__experimental__",
+        "min_value": 2,
+        "mostly": 0.1,
+        "row_condition": "col(\"category_id\")==1 and col(\"newsletter_id\")==Null"
+      },
+      "meta": {}
+    }
+  ],
+  "ge_cloud_id": null,
+  "meta": {
+    "citations": [
+      {
+        "batch_request": {
+          "data_asset_name": "newsletter_automation.articles",
+          "data_connector_name": "default_inferred_data_connector_name",
+          "datasource_name": "newsletter_automation_datasource",
+          "limit": 1000
+        },
+        "citation_date": "2022-07-27T06:06:14.035562Z",
+        "comment": "Created suite added via CLI"
+      }
+    ],
+    "great_expectations_version": "0.15.15"
+  }
+}


### PR DESCRIPTION
Task: Test to check if atleast one comic is ready with the title.

Steps followed:
-Created new test suite called comic_title_validations.json
- Updated checkpoint/newsletter_automation.yaml file
- Checking for the titles is present for the comic articles  and newsletter_id is to be Null.

Conditional Expectations used:
expect_column_values_to_be_between