### PR TITLE
Fixed issue by reloading page when there is no article selected

### DIFF
--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -169,17 +169,18 @@ def create_newsletter():
                     return redirect(url_for("create_newsletter"))
 
                 if article_id == "Select URL":
-                    flash('please select URL','danger')
-
+                    flash('Please select a URL','danger')
 
                 else:
-                    if article_id not in article_id_list:
+                    if article_id not in article_id_list and article_id is not None:
                         article_id_list.append(article_id)
                         articles_added.append(title)
                         return redirect(url_for("create_newsletter"))
                     else:
-                        flash('Already selected !! Please select another article ', 'danger')
-                        return redirect(url_for("create_newsletter"))
+                        if article_id:
+                            flash('Already selected !! Please select another article ', 'danger')
+                        else:
+                            return redirect(url_for("create_newsletter"))
 
             if form.preview_newsletter.data:
                 if subject and opener and preview_text and article_id_list:


### PR DESCRIPTION
I updated the bug to simply refresh the page if Preview newsletter was called without adding articles. This has the disadvantage of losing the filled up subject, opener and preview. But it has the advantage of not having to consider all sorts of asynch operations that can happen between two independent forms.