### PR TITLE
fix comic title validations

### DIFF
--- a/tests/data_validation/great_expectations/checkpoints/comic_title_validations.yml
+++ b/tests/data_validation/great_expectations/checkpoints/comic_title_validations.yml
@@ -22,10 +22,12 @@ runtime_configuration: {}
 validations:
   - batch_request:
       datasource_name: newsletter_automation_datasource
-      data_connector_name: default_inferred_data_connector_name
+      data_connector_name: default_runtime_data_connector_name
       data_asset_name: newsletter_automation.articles
-      data_connector_query:
-        index: -1
+      runtime_parameters:
+        query: SELECT * from newsletter_automation.articles WHERE newsletter_id is null
+      batch_identifiers:
+        default_identifier_name: comic_title_validator
     expectation_suite_name: comic_title_validations
 profilers: []
 ge_cloud_id:

--- a/tests/data_validation/great_expectations/expectations/comic_title_validations.json
+++ b/tests/data_validation/great_expectations/expectations/comic_title_validations.json
@@ -9,7 +9,7 @@
         "condition_parser": "great_expectations__experimental__",
         "min_value": 2,
         "mostly": 0.1,
-        "row_condition": "col(\"category_id\")==1 and col(\"newsletter_id\")==Null"
+        "row_condition": "col(\"category_id\")==1"
       },
       "meta": {}
     }


### PR DESCRIPTION
Modified files :
 checkpoints/comic_title_validations.yml
 expectations/comic_title_validations.json

I am using this as RuntimeDataconnector and runtime_parameter to filter out the articles for newsletter_id is null
And  updated the .json row_condition to category_id=1

To test the suite:
Run: `great_expectations checkpoint run comic_title_validations`

[https://github.com/qxf2/newsletter_automation/issues/146](url)
