### PR TITLE
Newsletter past articles ge tests raji latest

### DIFF
--- a/tests/data_validation/great_expectations/checkpoints/comic_title_validations.yml
+++ b/tests/data_validation/great_expectations/checkpoints/comic_title_validations.yml
@@ -3,7 +3,7 @@ config_version: 1.0
 template_name:
 module_name: great_expectations.checkpoint
 class_name: Checkpoint
-run_name_template: 'newsletter-automation'
+run_name_template: '%Y%m%d-%H%M%S-newsletter-automation'
 expectation_suite_name:
 batch_request: {}
 action_list:

--- a/tests/data_validation/great_expectations/checkpoints/past_articles_count_validations.yml
+++ b/tests/data_validation/great_expectations/checkpoints/past_articles_count_validations.yml
@@ -1,0 +1,35 @@
+name: past_articles_count_validations
+config_version: 1.0
+template_name:
+module_name: great_expectations.checkpoint
+class_name: Checkpoint
+run_name_template: '%Y%m%d-%H%M%S-my-run-name-template'
+expectation_suite_name: verify_past_articles_expectation_suite
+batch_request: {}
+action_list:
+  - name: store_validation_result
+    action:
+      class_name: StoreValidationResultAction
+  - name: store_evaluation_params
+    action:
+      class_name: StoreEvaluationParametersAction
+  - name: update_data_docs
+    action:
+      class_name: UpdateDataDocsAction
+      site_names: []
+evaluation_parameters: {}
+runtime_configuration: {}
+validations:
+  - batch_request:
+      datasource_name: newsletter_automation_datasource
+      data_connector_name: default_inferred_data_connector_name
+      data_asset_name: newsletter_automation.articles
+      runtime_parameters:
+        query: select * from newsletter_automation.articles where newsletter_id is null and description != "" and title != "" and category_id=2
+      batch_identifiers:
+        default_identifier_name: default_identifier
+    expectation_suite_name: verify_past_articles_expectation_suite
+
+profilers: []
+ge_cloud_id:
+expectation_suite_ge_cloud_id:

--- a/tests/data_validation/great_expectations/checkpoints/past_articles_count_validations.yml
+++ b/tests/data_validation/great_expectations/checkpoints/past_articles_count_validations.yml
@@ -22,7 +22,7 @@ runtime_configuration: {}
 validations:
   - batch_request:
       datasource_name: newsletter_automation_datasource
-      data_connector_name: default_inferred_data_connector_name
+      data_connector_name: default_runtime_data_connector_name
       data_asset_name: newsletter_automation.articles
       runtime_parameters:
         query: select * from newsletter_automation.articles where newsletter_id is null and description != "" and title != "" and category_id=2

--- a/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
+++ b/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
@@ -1,9 +1,61 @@
 {
   "data_asset_type": null,
   "expectation_suite_name": "verify_past_articles_expectation_suite",
-  "expectations": [],
+  "expectations": [
+    {
+      "expectation_type": "expect_table_row_count_to_be_between",
+      "kwargs": {
+        "min_value": 2
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_null",
+      "kwargs": {
+        "column": "newsletter_id",
+        "condition_parser": "great_expectations__experimental__",
+        "mostly": 0.2,
+        "row_condition": "col(\"category_id\")==2"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_value_lengths_to_be_between",
+      "kwargs": {
+        "column": "description",
+        "condition_parser": "great_expectations__experimental__",
+        "min_value": 10,
+        "mostly": 0.2,
+        "row_condition": "col(\"category_id\")==2"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_value_lengths_to_be_between",
+      "kwargs": {
+        "column": "title",
+        "condition_parser": "great_expectations__experimental__",
+        "min_value": 2,
+        "mostly": 0.2,
+        "row_condition": "col(\"category_id\")==2"
+      },
+      "meta": {}
+    }
+  ],
   "ge_cloud_id": null,
   "meta": {
+    "citations": [
+      {
+        "batch_request": {
+          "data_asset_name": "newsletter_automation.articles",
+          "data_connector_name": "default_inferred_data_connector_name",
+          "datasource_name": "my_mysql_datasource",
+          "limit": 1000
+        },
+        "citation_date": "2022-09-21T04:23:03.283243Z",
+        "comment": "Created suite added via CLI"
+      }
+    ],
     "great_expectations_version": "0.15.22"
   }
 }

--- a/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
+++ b/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
@@ -1,0 +1,9 @@
+{
+  "data_asset_type": null,
+  "expectation_suite_name": "verify_past_articles_expectation_suite",
+  "expectations": [],
+  "ge_cloud_id": null,
+  "meta": {
+    "great_expectations_version": "0.15.22"
+  }
+}

--- a/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
+++ b/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
@@ -48,7 +48,7 @@
       {
         "batch_request": {
           "data_asset_name": "newsletter_automation.articles",
-          "data_connector_name": "default_inferred_data_connector_name",
+          "data_connector_name": "default_runtime_data_connector_name",
           "datasource_name": "newsletter_automation_datasource",
           "limit": 1000
         },

--- a/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
+++ b/tests/data_validation/great_expectations/expectations/verify_past_articles_expectation_suite.json
@@ -49,7 +49,7 @@
         "batch_request": {
           "data_asset_name": "newsletter_automation.articles",
           "data_connector_name": "default_inferred_data_connector_name",
-          "datasource_name": "my_mysql_datasource",
+          "datasource_name": "newsletter_automation_datasource",
           "limit": 1000
         },
         "citation_date": "2022-09-21T04:23:03.283243Z",

--- a/tests/data_validation/great_expectations/utils/test_run_past_articles_count_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_past_articles_count_validations.py
@@ -36,4 +36,4 @@ def test_run_past_articles_count_validations():
     else:
         print("Validation succeeded!")
 
-    assert result["success","Looks like 2 past articles are not ready with description and title"]
+    assert result["success"],"Looks like 2 past articles are not ready with description and title"

--- a/tests/data_validation/great_expectations/utils/test_run_past_articles_count_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_past_articles_count_validations.py
@@ -1,0 +1,39 @@
+"""
+This is a basic generated Great Expectations script that runs a Checkpoint.
+Checkpoints are the primary method for validating batches of data in production and triggering any followup actions.
+A Checkpoint facilitates running a validation as well as configurable Actions such as updating Data Docs, sending a
+notification to team members about validation results, or storing a result in a shared cloud storage.
+See also <cyan>https://docs.greatexpectations.io/en/latest/guides/how_to_guides/validation/how_to_create_a_new_checkpoint_using_test_yaml_config.html</cyan> for more information about the Checkpoints and how to configure them in your Great Expectations environment.
+Checkpoints can be run directly without this script using the `great_expectations checkpoint run` command.  This script
+is provided for those who wish to run Checkpoints in python.
+Usage:
+- Run this file: `python great_expectations/utils/test_run_past_articles_count_validations.py`
+- This can be run manually or via a scheduler such, as cron.
+- If your pipeline runner supports python snippets, then you can paste this into your pipeline.
+"""
+import sys
+
+from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
+from great_expectations.data_context import DataContext
+import pytest
+
+@pytest.mark.CheckpointWednesday10am
+def test_run_past_articles_count_validations():
+    data_context = DataContext(context_root_dir="tests/data_validation/great_expectations")
+
+    checkpoint_name : str ="past_articles_count_validations"
+    batch_request : str = None
+    run_name : str = None
+
+    result : CheckpointResult = data_context.run_checkpoint(checkpoint_name=checkpoint_name,
+                                                            batch_request=batch_request,
+                                                            run_name=run_name)
+
+
+    if not result["success"]:
+        print("Validation failed!")
+        print(result)
+    else:
+        print("Validation succeeded!")
+
+    assert result["success","Looks like 2 past articles are not ready with description and title"]


### PR DESCRIPTION
Details of the PR:
Test: Check there are at least two articles from the past that are ready with description and title 
Changes: 
1. Added below run time query 
select * from newsletter_automation.articles where newsletter_id is null and description != "" and title != "" and category_id=2
2. Based on the run-time query, added an expectation to check if the above query result contains at least 2 records. This expectation alone would meet the given test 
3. Added an extra expectation to check if the description column length is atleast 10 characters 
4. Added an extra expectation to check if the title column length is atleast 2 characters 