### PR TITLE
updated requirements.txt to fix outside app context error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask
 Flask-WTF
 wtforms-components
-flask-sqlalchemy
+flask-sqlalchemy==2.5.1
 flask-migrate
 mailchimp-marketing==3.0.44
 pylint


### PR DESCRIPTION
To fix the outside context error, I have pinned the flask-sqlalchemy version to 2.5.1 in the requirements.txt file. 