### PR TITLE
validation on description field only on non blank values

### DIFF
--- a/tests/data_validation/great_expectations/checkpoints/description_validation.yml
+++ b/tests/data_validation/great_expectations/checkpoints/description_validation.yml
@@ -25,8 +25,7 @@ validations:
       data_connector_name: default_runtime_data_connector_name
       data_asset_name: newsletter_automation.articles
       runtime_parameters:
-        query: SELECT * from newsletter_automation.articles WHERE newsletter_id is
-          null and category_id != 1 and description <> ''
+        query: SELECT * from newsletter_automation.articles WHERE newsletter_id is null and category_id != 1 and description != ''
       batch_identifiers:
         default_identifier_name: test_identifier
     expectation_suite_name: description_title_validations

--- a/tests/data_validation/great_expectations/checkpoints/description_validation.yml
+++ b/tests/data_validation/great_expectations/checkpoints/description_validation.yml
@@ -26,7 +26,7 @@ validations:
       data_asset_name: newsletter_automation.articles
       runtime_parameters:
         query: SELECT * from newsletter_automation.articles WHERE newsletter_id is
-          null and category_id != 1
+          null and category_id != 1 and description <> ''
       batch_identifiers:
         default_identifier_name: test_identifier
     expectation_suite_name: description_title_validations


### PR DESCRIPTION
Earlier description field one liner validation applied for both blank and non blank field values. 
Now the description one liner validation appling only the field with non blank values by modifying the query in "description_validation.yml" to fetch only non blank values.