### PR TITLE
Added a MAILCHIMP_VIRTUALIZATION os environment variable to let the a…

### DIFF
--- a/newsletter_automation/helpers/mailchimp_helper.py
+++ b/newsletter_automation/helpers/mailchimp_helper.py
@@ -30,11 +30,14 @@ class Mailchimp_Helper:
     def set_mailchimp_config(self):
         "set mailchimp connection config"
         self.client = MailchimpMarketing.Client()
+        mailchimp_base_url = os.environ.get('MAILCHIMP_VIRTUALIZATION', None)
+        if mailchimp_base_url:
+            self.client.api_client.host = mailchimp_base_url
         self.client.set_config({
             "api_key": API_KEY,
             "server": SERVER_PREFIX
         })
-        
+
 
     def ping_mailchimp(self):
         "check mailchimp connection health"


### PR DESCRIPTION
We ended up resetting MailChimp helper. You can now set your virtualized URL in an envrionment variable MAILCHIMP_VIRTUALIZATION to point to the base URL of your virtualized service.

Example: export MAILCHIMP_VIRTUALIZATION = "https://blahblahblah.mocklab.io"