### PR TITLE
Fix ready article alarm

### DIFF
--- a/tests/data_validation/great_expectations/checkpoints/all_articles_count_validations.yml
+++ b/tests/data_validation/great_expectations/checkpoints/all_articles_count_validations.yml
@@ -18,14 +18,19 @@ action_list:
       class_name: UpdateDataDocsAction
       site_names: []
 evaluation_parameters: {}
-runtime_configuration: {}
+runtime_configuration: {
+        result_format: {
+            result_format: SUMMARY,
+            include_unexpected_rows: True
+        }
+    }
 validations:
   - batch_request:
       datasource_name: newsletter_automation_datasource
       data_connector_name: default_runtime_data_connector_name
       data_asset_name: newsletter_automation.articles
       runtime_parameters:
-        query: select count(*) as count,category_id from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null group by category_id
+        query: select count(*) as count,category_id from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null and category_id !=5 group by category_id
       batch_identifiers:
         default_identifier_name: validation_stage
     expectation_suite_name: all_articles_count_validations

--- a/tests/data_validation/great_expectations/checkpoints/all_articles_count_validations.yml
+++ b/tests/data_validation/great_expectations/checkpoints/all_articles_count_validations.yml
@@ -3,7 +3,7 @@ config_version: 1.0
 template_name:
 module_name: great_expectations.checkpoint
 class_name: Checkpoint
-run_name_template: 'newsletter automation-all articles count validation'
+run_name_template: 'Ready count'
 expectation_suite_name:
 batch_request: {}
 action_list:
@@ -28,11 +28,38 @@ validations:
   - batch_request:
       datasource_name: newsletter_automation_datasource
       data_connector_name: default_runtime_data_connector_name
-      data_asset_name: newsletter_automation.articles
+      data_asset_name: Comics
       runtime_parameters:
-        query: select count(*) as count,category_id from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null and category_id !=5 group by category_id
+        query: select * from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null and category_id = 1
       batch_identifiers:
-        default_identifier_name: validation_stage
+        default_identifier_name: ready_comics
+    expectation_suite_name: all_articles_count_validations
+  - batch_request:
+      datasource_name: newsletter_automation_datasource
+      data_connector_name: default_runtime_data_connector_name
+      data_asset_name: Past articles
+      runtime_parameters:
+        query: select * from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null and category_id = 2
+      batch_identifiers:
+        default_identifier_name: ready_past_articles
+    expectation_suite_name: all_articles_count_validations
+  - batch_request:
+      datasource_name: newsletter_automation_datasource
+      data_connector_name: default_runtime_data_connector_name
+      data_asset_name: Current week
+      runtime_parameters:
+        query: select * from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null and category_id = 3
+      batch_identifiers:
+        default_identifier_name: ready_current_week_articles
+    expectation_suite_name: all_articles_count_validations
+  - batch_request:
+      datasource_name: newsletter_automation_datasource
+      data_connector_name: default_runtime_data_connector_name
+      data_asset_name: Automation corner
+      runtime_parameters:
+        query: select * from newsletter_automation.articles where title !="" and description !="" and newsletter_id is null and category_id = 4
+      batch_identifiers:
+        default_identifier_name: ready_automation_corner_articles
     expectation_suite_name: all_articles_count_validations
 
 

--- a/tests/data_validation/great_expectations/expectations/all_articles_count_validations.json
+++ b/tests/data_validation/great_expectations/expectations/all_articles_count_validations.json
@@ -3,13 +3,11 @@
   "expectation_suite_name": "all_articles_count_validations",
   "expectations": [
     {
-      "expectation_type": "expect_column_values_to_be_between",
+      "expectation_type": "expect_table_row_count_to_be_between",
       "kwargs": {
-        "column": "count",
         "max_value": 10,
         "min_value": 1
-      },
-      "meta": {"Comic":1, "Past week":2, "Current week":3, "Automation corner":4}
+      }
     }
   ],
   "ge_cloud_id": null,

--- a/tests/data_validation/great_expectations/expectations/all_articles_count_validations.json
+++ b/tests/data_validation/great_expectations/expectations/all_articles_count_validations.json
@@ -7,9 +7,9 @@
       "kwargs": {
         "column": "count",
         "max_value": 10,
-        "min_value": 0
+        "min_value": 1
       },
-      "meta": {}
+      "meta": {"Comic":1, "Past week":2, "Current week":3, "Automation corner":4}
     }
   ],
   "ge_cloud_id": null,

--- a/tests/data_validation/great_expectations/utils/test_run_all_articles_count_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_all_articles_count_validations.py
@@ -17,7 +17,7 @@ from great_expectations.checkpoint.types.checkpoint_result import CheckpointResu
 from great_expectations.data_context import DataContext
 import pytest
 
-@pytest.mark.CheckpointFriday04pm
+@pytest.mark.CheckpointWednesday10am
 def test_run_all_articles_count_validations():
     data_context = DataContext(context_root_dir="tests/data_validation/great_expectations")
 
@@ -26,14 +26,12 @@ def test_run_all_articles_count_validations():
     run_name : str = None
 
     result : CheckpointResult = data_context.run_checkpoint(checkpoint_name=checkpoint_name,
-                                                            batch_request=batch_request,
-                                                            run_name=run_name)
-
+    batch_request=batch_request,
+    run_name=run_name)
 
     if not result["success"]:
         print("Validation failed!")
-        print(result)
     else:
         print("Validation succeeded!")
 
-    assert result["success"], "Many edited articles are yet to make it to our Newsletter edition!"
+    assert result["success"], f"We either have no article ready or too many articles ready!"


### PR DESCRIPTION
1. Split checking of 'ready articles' count into 4 batches - one per category
2. Changed the expectation to count rows
3. Updated the run name and asset name to make reporting clearer
4. Changed the marker on the test to run on Wednesday morning