### PR TITLE
Dal 79 delete article api

### DIFF
--- a/newsletter_automation/newsletter/routes.py
+++ b/newsletter_automation/newsletter/routes.py
@@ -458,9 +458,10 @@ def delete_article(article_id):
 
     return redirect(url_for("manage_articles"))
 
-@app.route("/delete/<article_id>", methods=["DELETE"])
+@app.route("/api/article/<article_id>", methods=["DELETE"])
 @Authentication_Required.requires_apikey
-def delete_article(article_id):
+@csrf.exempt
+def delete_article_api(article_id):
     "Deletes an article"
     msg = {'Message': f'Success. Deleted article with id {article_id}', 'Error': None}
     try:


### PR DESCRIPTION
I have added the endpoint /api/articles/<article id> for deleting an article

B. If all goes well, we will return the JSON : 

{
  "Error": null, 
  "Message": "Success. Deleted article with id 234"
}
C. If something goes wrong (e.g.: id is not valid), we will return a JSON that will contain the exact Python exception as the error:

{
  "Error": "Python exception says: Class 'builtins.NoneType' is not mapped", 
  "Message": "Fail. Could not delete the article with id 12345"
} 
D. If the article is already part of a newsletter, we will not delete the article. Instead, we will return the JSON:

{
  "Error": "Article already present in a newsletter", 
  "Message": "Fail. Could not delete the article with id: 228"
}