### PR TITLE
Fix ge workflow error

### DIFF
--- a/.github/workflows/run_ge_test.yaml
+++ b/.github/workflows/run_ge_test.yaml
@@ -39,7 +39,7 @@ jobs:
           pip install great_expectations
           pip install pytest
           pip install pymysql
-          pip install SQLAlchemy
+          pip install SQLAlchemy<2.0
 
       - name: Run CheckpointWednesday10am
         if: ${{ github.event.schedule == '30 4 * * 3' }}

--- a/.github/workflows/run_ge_test.yaml
+++ b/.github/workflows/run_ge_test.yaml
@@ -49,10 +49,6 @@ jobs:
         if: ${{ github.event.schedule == '30 10 * * 5' }}
         run: |
           pytest tests/data_validation/great_expectations/utils/ -s -v -m CheckpointFriday04pm
-      - name: Run CheckpointWednesday04pm
-        if: ${{ github.event.schedule == '30 10 * * 3' }}
-        run: |
-          pytest tests/data_validation/great_expectations/utils/ -s -v -m CheckpointWednesday04pm
 
       - name: Deploy DataDocs to Netlify
         if: always()

--- a/tests/data_validation/great_expectations/utils/test_run_all_articles_count_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_all_articles_count_validations.py
@@ -34,4 +34,7 @@ def test_run_all_articles_count_validations():
     else:
         print("Validation succeeded!")
 
+    # print result to assist debug
+    print(f"The Result is {result}")
+
     assert result["success"], f"We either have no article ready or too many articles ready!"

--- a/tests/data_validation/great_expectations/utils/test_run_comic_title_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_comic_title_validations.py
@@ -41,4 +41,7 @@ def test_comic_title_validations():
     else:
         print("Validation succeeded!")
 
+    # print result to assist debug
+    print(f"The Result is {result}")
+
     assert result["success"], "No comic is ready with a title!"

--- a/tests/data_validation/great_expectations/utils/test_run_current_week_article_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_current_week_article_validations.py
@@ -42,4 +42,7 @@ def test_run_checkpoint():
     else:
         print("Validation succeeded!")
 
+    # print result to assist debug
+    print(f"The Result is {result}")
+
     assert result["success"], "No articles from current week are ready with a description and title!"

--- a/tests/data_validation/great_expectations/utils/test_run_description_validation.py
+++ b/tests/data_validation/great_expectations/utils/test_run_description_validation.py
@@ -43,4 +43,7 @@ def test_run_checkpoint():
     print("Validation succeeded!")
     sys.exit(0)
 
-    assert result["Success"], "Lazy one liners in the description of the articles!"
+    # print result to assist debug
+    print(f"The Result is {result}")
+
+    assert result["success"], "Lazy one liners in the description of the articles!"

--- a/tests/data_validation/great_expectations/utils/test_run_past_articles_count_validations.py
+++ b/tests/data_validation/great_expectations/utils/test_run_past_articles_count_validations.py
@@ -36,4 +36,7 @@ def test_run_past_articles_count_validations():
     else:
         print("Validation succeeded!")
 
+    # print result to assist debug
+    print(f"The Result is {result}")
+
     assert result["success"],"Looks like 2 past articles are not ready with description and title!"


### PR DESCRIPTION
Changes made to fix the `run_ge_test` workflow error:
- Change the `SQLAlchemy` version to be `<2.0`
  >GE is incompatible with SQLAlchemy 2.0
- Print the result in every test
  >Helps with first level of debug, allows viewing result in the workflow log
- Fix the dictionary key error in lazy desc test
  >Fixed a typo
- Remove the checkpoint `CheckpointWednesday04pm`
  >There aren't any test marked for this checkpoint