### PR TITLE
Removed the trigger to run the GE test on Wednesday's at 4:00 PM

### DIFF
--- a/.github/workflows/run_ge_test.yaml
+++ b/.github/workflows/run_ge_test.yaml
@@ -7,8 +7,6 @@ on:
     - cron: "30 4 * * 3"
   # Every Friday at 4pm IST
     - cron: "30 10 * * 5"
-  # Every Wednesday at 4pm IST
-    - cron: "30 10 * * 3"
 
 env:
   DB_HOST: ${{ secrets.HOST }}


### PR DESCRIPTION
Removed the `cron schedule` trigger, to not run the workflow on `Wednesday's 4:00 PM`